### PR TITLE
fix(lint/noUnassignedVariables): handle JSX ref attribute assignments

### DIFF
--- a/crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx
@@ -1,0 +1,5 @@
+/* should not generate diagnostics */
+export const Bug = () => {
+    let value;
+    return <div ref={value} />
+  }

--- a/crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx.snap
+++ b/crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx.snap
@@ -1,0 +1,12 @@
+---
+source: crates/biome_js_analyze/tests/spec_tests.rs
+expression: valid.jsx
+---
+# Input
+```jsx
+/* should not generate diagnostics */
+export const Bug = () => {
+    let value;
+    return <div ref={value} />
+  }
+```

--- a/crates/biome_js_semantic/src/events.rs
+++ b/crates/biome_js_semantic/src/events.rs
@@ -6,7 +6,9 @@ use biome_js_syntax::{
     AnyJsIdentifierUsage, JsDirective, JsLanguage, JsSyntaxKind, JsSyntaxNode, TextRange,
     TsTypeParameterName, inner_string_text,
 };
-use biome_js_syntax::{AnyJsImportClause, AnyJsNamedImportSpecifier, AnyTsType};
+use biome_js_syntax::{
+    AnyJsImportClause, AnyJsNamedImportSpecifier, AnyJsxAttributeName, AnyTsType, JsxAttribute,
+};
 use biome_rowan::TextSize;
 use biome_rowan::{AstNode, SyntaxNodeOptionExt, TokenText, syntax::Preorder};
 use rustc_hash::FxHashMap;
@@ -709,6 +711,18 @@ impl SemanticEventExtractor {
         }
     }
 
+    fn is_inside_jsx_ref_attribute(node: &JsSyntaxNode) -> bool {
+        node.ancestors()
+            .find_map(|ancestor| JsxAttribute::cast(ancestor))
+            .and_then(|attr| attr.name().ok())
+            .is_some_and(|attr_name| match attr_name {
+                AnyJsxAttributeName::JsxName(jsx_name) => jsx_name
+                    .value_token()
+                    .is_ok_and(|token| token.text_trimmed() == "ref"),
+                _ => false,
+            })
+    }
+
     fn enter_identifier_usage(&mut self, node: AnyJsIdentifierUsage) {
         let range = node.syntax().text_trimmed_range();
         let Ok(name_token) = node.value_token() else {
@@ -728,6 +742,14 @@ impl SemanticEventExtractor {
                     );
                     return;
                 };
+
+                if parent.kind() == JS_IDENTIFIER_EXPRESSION
+                    && Self::is_inside_jsx_ref_attribute(&parent)
+                {
+                    self.push_reference(BindingName::Value(name), Reference::Write(range));
+                    return;
+                }
+
                 match parent.kind() {
                     JS_EXPORT_NAMED_SHORTHAND_SPECIFIER | JS_EXPORT_NAMED_SPECIFIER => {
                         self.push_reference(


### PR DESCRIPTION
## Summary
Closes #6795

The `noUnassignedVariables` rule was incorrectly flagging variables used in JSX `ref` attributes as
unassigned. This occurred because JSX ref attributes were not being recognized as write references in the
semantic analyzer.

This PR fixes the issue by adding proper detection for JSX ref attribute usage, ensuring that variables
assigned to `ref` props are correctly tracked as write references.


## Test Plan
Added test cases in `crates/biome_js_analyze/tests/specs/nursery/noUnassignedVariables/valid.jsx` to verify
that JSX ref attributes are correctly handled:

```jsx
export const Bug = () => {
    let value;
    return <div ref={value} />
}
```

The snapshot test confirms that no diagnostic is generated for this valid usage pattern.

## Docs
No documentation changes needed as this is a bug fix that corrects the existing behavior of the noUnassignedVariables rule.
